### PR TITLE
Use path helper for cross paltform compatibility

### DIFF
--- a/lib/config_reader.js
+++ b/lib/config_reader.js
@@ -2,9 +2,10 @@
 
 const nconf = require('nconf');
 const debug = require('debug')('configReader');
+const path = require('path');
 
 const configReader = function configReader(config_file_path) {
-  nconf.file(config_file_path);
+  nconf.file(path.normalize(config_file_path));
   debug(`loaded config '${config_file_path}'`);
 
   const get = function get(var_name) {


### PR DESCRIPTION
AdADay is broken in Windows because paths were specified the UNIX way. The
helper now parses the paths into whatever format the platform requires.
