### PR TITLE
Fix typo in time zone property name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Because there aren't enough ads in your life already.
 - Get your tokens from
 [Slack](https://my.slack.com/services/new/incoming-webhook/) and copy them into
 the `config.json` file.
-- Set your timezone, the days, and the time when AdADay should post to Slack.
+- Set your time zone, the days, and the time when AdADay should post to Slack.
 - The possible values for `publish_on` are `weekdays` or `anyday`.
 - `publish_at` is the time when the ad will be posted. Any time in 24h format
 written as `hh:mm` can be set.
-- The `timezone` will be used to interpret the `publish_at` time entered. A list
-of timezones is available [here](http://momentjs.com/timezone/).
+- The `time_zone` will be used to interpret the `publish_at` time entered. A
+  list of time zones is available [here](http://momentjs.com/time_zone/).
 - The `min_score` setting is the cut-off value under which the ad is rejected.
 Scores range from `0` to `5`. Valid values are `0`, `1`, `2`, `3`, `4`, `5`.
 The more recent videos have a score of 0.0 or 5.0; it seems there used to be a

--- a/fixtures/config_anyday.json
+++ b/fixtures/config_anyday.json
@@ -13,6 +13,6 @@
   "app": {
     "publish_on": "anyday",
     "publish_at": "09:30",
-    "timezone": "America/Toronto"
+    "time_zone": "America/Toronto"
   }
 }

--- a/fixtures/config_weekdays.json
+++ b/fixtures/config_weekdays.json
@@ -13,6 +13,6 @@
   "app": {
     "publish_on": "weekdays",
     "publish_at": "09:30",
-    "timezone": "America/Toronto"
+    "time_zone": "America/Toronto"
   }
 }

--- a/lib/adaday.js
+++ b/lib/adaday.js
@@ -8,7 +8,7 @@ const slackPublisher = require('./slack_publisher.js').create();
 const configReader = require('./config_reader.js').create('config.json');
 
 const adADay = function adADay() {
-  moment.tz.setDefault(configReader.get('app:timezone'));
+  moment.tz.setDefault(configReader.get('app:time_zone'));
   const isDayMatch = function isTimeToPublish() {
     const DAY_IDS = {
       'Monday': 1,


### PR DESCRIPTION
The example config file used `time_zone` but the code was looking for `timezone`. The test config files also used `timezone` so the bug wasn't detected.

Since the English words are "time zone" and there is a space inbetween, it makes sense to name the option `time_zone` rather than `timezone`.
